### PR TITLE
set prior for sigma_RAW in hier models

### DIFF
--- a/inst/stan/fpem_spline.stan
+++ b/inst/stan/fpem_spline.stan
@@ -223,11 +223,11 @@ transformed parameters {
 
 model {
   // P_tilde
-  P_tilde_sigma ~ std_normal();
+  P_tilde_sigma_raw ~ std_normal();
   P_tilde_raw   ~ std_normal();
 
   // Omega
-  Omega_sigma ~ std_normal();
+  Omega_sigma_raw ~ std_normal();
   Omega_raw   ~ std_normal();
 
 
@@ -238,7 +238,7 @@ model {
   }
 
   to_vector(a_raw) ~ std_normal();
-  to_vector(a_sigma) ~ std_normal();
+  to_vector(a_sigma_raw) ~ std_normal();
 
   nonse ~ normal(0, 0.1);
 


### PR DESCRIPTION
Add "raw" to the sigmas for parameters in hierarchical models (Omega, a, and P_tilde) In model block in  fpem_spline.stan. This does not change the output but improves clarity on set up. 
